### PR TITLE
Substituindo ocorrencias de array em formato '[0]' por '->item(0)'

### DIFF
--- a/builder/LeituraBuilder.php
+++ b/builder/LeituraBuilder.php
@@ -16,7 +16,7 @@ class LeituraBuilder {
     }
 
     private function titulo() {
-        return $this->leitura->getElementsByTagName("h3")[0];
+        return $this->leitura->getElementsByTagName("h3")->item(0);
     }
 
     private function texto() {
@@ -24,6 +24,6 @@ class LeituraBuilder {
         //    print_r($node);
 
         // FIXME - O número [5] é sem sentido
-        return $this->leitura->childNodes[5];
+        return $this->leitura->childNodes->item(5);
     }
 }

--- a/page/LiturgiaDiariaPage.php
+++ b/page/LiturgiaDiariaPage.php
@@ -23,13 +23,13 @@ class LiturgiaDiariaPage extends Page {
     }
 
     public function getTitulo() {
-        return HTMLUtils::removeBreak($this->finder->query("//h2")[0]->nodeValue);
+        return HTMLUtils::removeBreak($this->finder->query("//h2")->item(0)->nodeValue);
     }
 
     public function getCor() {
         //.container em
         $query = "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' container ')]/descendant::em";
-        return HTMLUtils::removeBreak($this->finder->query($query)[0]->nodeValue);
+        return HTMLUtils::removeBreak($this->finder->query($query)->item(0)->nodeValue);
     }
 
     public function getLeituras() {


### PR DESCRIPTION
O formato anterior está funcionando normalmente em ambiente local. Porém, quando está em ambiente de produção recebemos o seguinte erro:

Fatal error: Cannot use object of type DOMNodeList as array in ../../../liturgia-diaria/page/LiturgiaDiariaPage.php on line 26.